### PR TITLE
Prevent `onerror` handler from throwing when the error object is undefined

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,16 +34,17 @@ export default ({onError, CsrfProtection}) => {
       const script = html`
 <script nonce="${ctx.nonce}">
 onerror = function(m,s,l,c,e) {
-  if (!e || e.__handled) return;
+  var _e = e || {};
+  if (_e.__handled) return;
   var error = {};
-  Object.getOwnPropertyNames(e).forEach(function(key) {
+  Object.getOwnPropertyNames(_e).forEach(function(key) {
     error[key] = e[key];
   });
   var x = new XMLHttpRequest;
   x.open('POST', '${ctx.prefix}/_errors');
   x.setRequestHeader('Content-Type', 'application/json')
   x.send(JSON.stringify({message: m, source: s, line: l, col: c, error: error}));
-  e.__handled = true;
+  _e.__handled = true;
 };
 </script>`;
       ctx.body.head.unshift(script);

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,7 @@ export default ({onError, CsrfProtection}) => {
       const script = html`
 <script nonce="${ctx.nonce}">
 onerror = function(m,s,l,c,e) {
-  if (e.__handled) return;
+  if (!e || e.__handled) return;
   var error = {};
   Object.getOwnPropertyNames(e).forEach(function(key) {
     error[key] = e[key];


### PR DESCRIPTION
fixes #9 