### PR TITLE
Add Token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Build status](https://badge.buildkite.com/1a76dbe95f76cd888a286290c365fabd54fcc62edb3895aa5d.svg?branch=master)](https://buildkite.com/uberopensource/fusion-plugin-error-handling)
 
-Collects browser errors, server request errors, and uncaught exceptions, and provides an api for handling them.
+Collects browser errors, server request errors, and uncaught exceptions, and provides an API for handling them.
+
+---
 
 ### Installation
 
@@ -10,24 +12,26 @@ Collects browser errors, server request errors, and uncaught exceptions, and pro
 yarn add fusion-plugin-error-handling
 ```
 
+---
+
 ### Example
 
 ```js
 // src/main.js
 import React from 'react';
 import App from 'fusion-react';
-import Monitoring from './monitoring';
+import registerMonitoring from './monitoring';
 
 export default () => {
   const app = new App(<div></div>);
-  app.plugin(Monitoring);
+  registerMonitoring(app);
   return app;
 }
 
 // src/monitoring.js
-import ErrorHandling from 'fusion-plugin-error-handling';
+import ErrorHandlingPlugin, {ErrorHandlerToken} from 'fusion-plugin-error-handling';
 
-export default ({}) => {
+export default (app) => {
   if (__NODE__) {
     const log = (e, captureType) => {
       if (captureType === 'browser') {
@@ -39,14 +43,25 @@ export default ({}) => {
         console.log('REQUEST ERROR');
       }
     }
-    return ErrorHandling({onError: log});
+    // Register dependencies
+    app.register(ErrorHandlerToken, log);
+    app.register(ErrorHandlingPlugin);
   }
 }
 ```
 
+---
+
 ### API
 
-`ErrorHandling({onError, CsrfProtection})`
+#### Dependency registration
+```js
+import {ErrorHandlerToken} from 'fusion-plugin-error-handling';
 
-- `onError: (e: Error, captureType: 'browser' | 'uncaught' | 'request') => Promise` - Required. A function that gets called on server errors. If the error is a global uncaught exception or unhandled rejection, the process exits when the returned Promise resolves/rejects.
-- `CsrfProtection` - Optional. Pass your [`fusion-plugin-csrf-protection`](https://github.com/fusionjs/fusion-plugin-csrf-protection) plugin to this package if CSRF protection is enabled, in order to allow errors to be logged without needing a CSRF token.
+__NODE__ && app.register(ErrorHandlerToken, /*some error handler*/);
+```
+
+##### Required dependencies
+Name | Type | Description
+-|-|-|-
+`ErrorHandlerToken` | `(e: Error, captureType: 'browser' | 'uncaught' | 'request') => Promise` | A function that gets called on server errors. If the error is a global uncaught exception or unhandled rejection, the process exits when the returned Promise resolves/rejects.  Server-side only.

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ __NODE__ && app.register(ErrorHandlerToken, /*some error handler*/);
 
 ##### Required dependencies
 Name | Type | Description
--|-|-|-
-`ErrorHandlerToken` | `(e: Error, captureType: 'browser' | 'uncaught' | 'request') => Promise` | A function that gets called on server errors. If the error is a global uncaught exception or unhandled rejection, the process exits when the returned Promise resolves/rejects.  Server-side only.
+-|-|-
+`ErrorHandlerToken` | `(e: Error, captureType: 'browser' or 'uncaught' or 'request') => Promise` | A function that gets called on server errors. If the error is a global uncaught exception or unhandled rejection, the process exits when the returned Promise resolves/rejects.  Server-side only.


### PR DESCRIPTION
Fixes #68  | Rendered: [link](https://github.com/AlexMSmithCA/fusion-plugin-error-handling/blob/0ed649265cd1886aa6a7085d81b2ba884e35c2d6/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation