### PR TITLE
Fix lint errors

### DIFF
--- a/fixtures/uncaught-exception.js
+++ b/fixtures/uncaught-exception.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const App = require('fusion-core').default;
+// eslint-disable-next-line import/no-unresolved
 const {default: Plugin, ErrorHandlerToken} = require('../dist/index.js');
 
 const onError = e => {

--- a/fixtures/unhandled-rejection.js
+++ b/fixtures/unhandled-rejection.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const App = require('fusion-core').default;
+// eslint-disable-next-line import/no-unresolved
 const {default: Plugin, ErrorHandlerToken} = require('../dist/index.js');
 
 const onError = e => {


### PR DESCRIPTION
Lint errors are throw if package has not been transpiled (e.g. in CI). This PR fixes that