### PR TITLE
Fix opener access errors

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -54,7 +54,7 @@ test('Get exception stack frames', t => {
 });
 
 test("Don't break on cross-origin exceptions", t => {
-  t.plan(0);
+  t.plan(1);
 
   const app = new App('test', el => el);
 
@@ -70,7 +70,7 @@ test("Don't break on cross-origin exceptions", t => {
 
   app.register(ErrorHandlingPlugin);
 
-  getSimulator(app);
+  t.doesNotThrow(() => getSimulator(app));
 
   t.end();
 });

--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -53,17 +53,20 @@ test('Get exception stack frames', t => {
   t.end();
 });
 
-test('Don\'t break on cross-origin exceptions', t => {
+test("Don't break on cross-origin exceptions", t => {
   t.plan(0);
 
   const app = new App('test', el => el);
 
-  window.opener = new Proxy({}, {
-    get: () => {
-      // Simulate an Exception on all access to `window.opener`
-      throw new Error('Simulated `DOMException`');
+  window.opener = new Proxy(
+    {},
+    {
+      get: () => {
+        // Simulate an Exception on all access to `window.opener`
+        throw new Error('Simulated `DOMException`');
+      },
     }
-  });
+  );
 
   app.register(ErrorHandlingPlugin);
 

--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -52,3 +52,22 @@ test('Get exception stack frames', t => {
 
   t.end();
 });
+
+test('Don\'t break on cross-origin exceptions', t => {
+  t.plan(0);
+
+  const app = new App('test', el => el);
+
+  window.opener = new Proxy({}, {
+    get: () => {
+      // Simulate an Exception on all access to `window.opener`
+      throw new Error('Simulated `DOMException`');
+    }
+  });
+
+  app.register(ErrorHandlingPlugin);
+
+  getSimulator(app);
+
+  t.end();
+});

--- a/src/client.js
+++ b/src/client.js
@@ -34,7 +34,7 @@ const plugin =
           throw e;
         };
       }
-      for (const key in window) {
+      const addListener = key => {
         if (
           key.match(/webkit/) == null && // stop deprecation warnings
           window[key] &&
@@ -54,6 +54,13 @@ const plugin =
             };
             return old.call(this, type, cb, ...rest);
           };
+        }
+      };
+      for (const key in window) {
+        try {
+          addListener(key);
+        } catch (e) {
+          // Ignore. Don't have access to the prop, possibly cross-origin restriction.
         }
       }
       window.addEventListener('unhandledrejection', e => {


### PR DESCRIPTION
Currently, if a page with this plugin is opened after clicking a link from an external domain, an error is thrown during app initialisation:

`DOMException: Blocked a frame with origin "https://<my_domain>" from accessing a cross-origin frame.`

This is due to Chrome preventing any (even read) access to `window.opener` in such cases.

This PR provides a test case + fixes the issue by adding a try/catch around the event binding. I possibly could have gone with a known-blacklist but IMO this is a safe, future-proof approach.