### PR TITLE
Remove fusion-token as a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,14 @@
     "eslint-plugin-react": "7.10.0",
     "flow-bin": "^0.75.0",
     "fusion-core": "^1.3.1",
-    "fusion-test-utils": "^1.1.0",
-    "fusion-tokens": "^1.0.3",
+    "fusion-test-utils": "^1.2.2-0",
     "nyc": "^12.0.0",
     "prettier": "^1.12.1",
     "tape-cup": "4.7.1",
     "unitest": "2.1.1"
   },
   "peerDependencies": {
-    "fusion-core": "^1.2.0",
-    "fusion-tokens": "^1.0.2"
+    "fusion-core": "^1.2.0"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,17 +2479,13 @@ fusion-core@^1.3.1:
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
 
-fusion-test-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.1.0.tgz#1900a7d432733f935698ee139cef3a1e8f6ab973"
+fusion-test-utils@^1.2.2-0:
+  version "1.2.2-0"
+  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.2.2-0.tgz#5336ba94c491311694281da258c3a859693a3b23"
   dependencies:
     assert "^1.4.1"
     koa "^2.4.1"
     node-mocks-http "^1.6.6"
-
-fusion-tokens@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fusion-tokens/-/fusion-tokens-1.0.3.tgz#e247a076ef145337287e103ecbc42486594e96c5"
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
`fusion-tokens` was unused. The peerDep was necessary for `fusion-test-utils` but since the new version removes it as a peerDep we don't need it here anymore either.