### PR TITLE
Update fusion-test-utils version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "7.10.0",
     "flow-bin": "^0.76.0",
     "fusion-core": "^1.3.1",
-    "fusion-test-utils": "^1.2.2-0",
+    "fusion-test-utils": "^1.2.2",
     "nyc": "^12.0.0",
     "prettier": "^1.12.1",
     "tape-cup": "4.7.1",


### PR DESCRIPTION
Since we cut the actual version last week, we can get rid of the old pin.